### PR TITLE
Fix for embedded base64 encoded images

### DIFF
--- a/easy_pdf/rendering.py
+++ b/easy_pdf/rendering.py
@@ -30,6 +30,9 @@ def fetch_resources(uri, rel):
         path = os.path.join(settings.STATIC_ROOT, uri.replace(settings.STATIC_URL, ""))
     elif settings.MEDIA_URL and uri.startswith(settings.MEDIA_URL):
         path = os.path.join(settings.MEDIA_ROOT, uri.replace(settings.MEDIA_URL, ""))
+    elif uri.startswith('data:image/'):
+        # If using embedded Base64 encoded image, simply return the uri
+        return uri
     else:
         path = os.path.join(settings.STATIC_ROOT, uri)
 

--- a/easy_pdf/rendering.py
+++ b/easy_pdf/rendering.py
@@ -26,13 +26,14 @@ def fetch_resources(uri, rel):
     :rtype: str
     :raises: :exc:`~easy_pdf.exceptions.UnsupportedMediaPathException`
     """
+    if uri.startswith('data:image/'):
+        # If using embedded Base64 encoded image, simply return the uri
+        return uri
+
     if settings.STATIC_URL and uri.startswith(settings.STATIC_URL):
         path = os.path.join(settings.STATIC_ROOT, uri.replace(settings.STATIC_URL, ""))
     elif settings.MEDIA_URL and uri.startswith(settings.MEDIA_URL):
         path = os.path.join(settings.MEDIA_ROOT, uri.replace(settings.MEDIA_URL, ""))
-    elif uri.startswith('data:image/'):
-        # If using embedded Base64 encoded image, simply return the uri
-        return uri
     else:
         path = os.path.join(settings.STATIC_ROOT, uri)
 


### PR DESCRIPTION
Embedded base64 encoded images are not file-paths and shouldn't be treated as such.